### PR TITLE
Add support for Jekyll 3 and provide additional configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,43 @@ This plugin makes it possible to automatically syndicate your posts to [Medium](
 
 Add `crosspost_to_medium: true` to the front matter for any post you would like to crosspost to Medium.
 
-Crossposted files will be logged in `.cache/medium_crossposted.yml`, so make sure that file gets checked into your Git repo if you work from multiple computers. That will enssure you never crosspost an entry more than once.
+## Configuation options
 
-You can control crossposting globally by setting the same variable in your Jekyll configuration file. Setting it to false will skip the processing loop entirely, which can be useful for local preview builds.
+This plugin takes a number of configuration options. These allow you to customise how the plugin works and what metadata is included when you syndicate to Medium. The following options are available:
 
-## A Note on Envitronment Variables
+```
+jekyll-crosspost_to_medium:
+  enabled: true | false
+  cache: .jekyll-crosspost_to_medium
+  status: public | draft | unlisted
+  license: all-rights-reserved | cc-40-by | cc-40-by-sa | cc-40-by-nd | cc-40-by-nc | cc-40-by-nc-nd | cc-40-by-nc-sa | cc-40-zero | public-domain
+```
+
+### `enabled`
+
+Default: `true`
+
+Controls crossposting globally. Setting this to false will skip the processing loop entirely which can be useful for local preview builds.
+
+### `cache`
+
+Default: `[source directory]/.jekyll-crosspost_to_medium`
+
+The name of the diretory where crossposted files will be logged. Make sure this file gets checked into your Git repo if you work from multiple computers. This will ensure you never crosspost an entry more than once.
+
+### `status`
+
+Default: `public`
+
+The status your post is given when it is syndicated to Medium.
+
+### `license`
+
+Default: `all-rights-reserved`
+
+The license your post is given when it is syndicated to Medium.
+
+## A Note on Environment Variables
 
 If you are having problems setting up Environment Variables, check out these guides:
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This plugin makes it possible to automatically syndicate your posts to [Medium](
 
 ## Crossposting
 
-Add `crosspost_to_medium: true` to the front matter for any post you would like to crosspost to Medium.
+Add `crosspost_to_medium: true` to the front matter of any post you would like to crosspost to Medium.
 
-## Configuation options
+## Configuation
 
 This plugin takes a number of configuration options. These allow you to customise how the plugin works and what metadata is included when you syndicate to Medium. The following options are available:
 
-```
+```yaml
 jekyll-crosspost_to_medium:
   enabled: true | false
   cache: .jekyll-crosspost_to_medium
@@ -26,29 +26,29 @@ jekyll-crosspost_to_medium:
   license: all-rights-reserved | cc-40-by | cc-40-by-sa | cc-40-by-nd | cc-40-by-nc | cc-40-by-nc-nd | cc-40-by-nc-sa | cc-40-zero | public-domain
 ```
 
-### `enabled`
+* `enabled`
 
-Default: `true`
+    Default: `true`
 
-Controls crossposting globally. Setting this to false will skip the processing loop entirely which can be useful for local preview builds.
+    Controls crossposting globally. Setting this to false will skip the processing loop entirely which can be useful for local preview builds.
 
-### `cache`
+* `cache`
 
-Default: `[source directory]/.jekyll-crosspost_to_medium`
+    Default: `[source directory]/.jekyll-crosspost_to_medium`
 
-The name of the diretory where crossposted files will be logged. Make sure this file gets checked into your Git repo if you work from multiple computers. This will ensure you never crosspost an entry more than once.
+    The name of the diretory where crossposted files will be logged. Make sure this file gets checked into your Git repo if you work from multiple computers. This will ensure you never crosspost an entry more than once.
 
-### `status`
+* `status`
 
-Default: `public`
+    Default: `public`
 
-The status your post is given when it is syndicated to Medium.
+    The status your post is given when it is syndicated to Medium.
 
-### `license`
+* `license`
 
-Default: `all-rights-reserved`
+    Default: `all-rights-reserved`
 
-The license your post is given when it is syndicated to Medium.
+    The license your post is given when it is syndicated to Medium.
 
 ## A Note on Environment Variables
 


### PR DESCRIPTION
Hello Aaron,

I hope you don’t mind, but I wish to suggest a couple of changes/improvements for this rather wonderful plugin:

* **Jekyll 3 support:** Not only does the latest version of Jekyll have a few API changes and deprecations, but it also introduced a hooks interface for plugins. I’ve refactored the code slightly so that both post loops (`Jekyll::Hooks.register :posts, :post_render do |post|` for Jekyll 3, `site.posts do |post|` for older versions) call a `crosspost_payload` definition. One issue I did notice using the old posts loop, is that liquid variables don’t get transformed. As hooks takes the already rendered code, this isn’t an issue for users of Jekyll 3. I tried to fix it for the older loop method, but it didn’t look easy — and is actually what led me to implementing the hook based approach.

* **Configuration options:** Ideally, it would be great if this plugin was available as a Ruby Gem (and more than happy to help out on that front). Yet, to do that, there needs to be some flexibility for authors, as the plugin code would be abstracted away. With that in mind, I’ve exposed a few of the Medium API options, and also allow users to define where the cache folder is created. I’ve given this a default value of `.jekyll-crosspost_to_medium`, which follows conventions used by other plugins, as well as Jekyll itself (which uses `.jekyll-metadata`). The config variable is also based on [existing conventions](https://github.com/jekyll/jekyll-archives/issues/3).

I'm no Ruby expert, but slowly learning by doing! I’ve been using this on my own site, but no doubt needs further testing, especially on older versions of Jekyll.

Do let me know if you have any feedback. And if you have a chance to test it with your own site, that’d be useful too.

Best,

Paul